### PR TITLE
[feat] Swagger 연동

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ dependencies {
 	implementation group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.2'
 
 	//	spring-doc
-	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2")
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,9 @@ dependencies {
 	implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.2'
 	implementation group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.2'
 	implementation group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.2'
+
+	//	spring-doc
+	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2")
 }
 
 tasks.named('test') {

--- a/src/main/java/org/sopt/sweet/domain/gift/controller/GiftApi.java
+++ b/src/main/java/org/sopt/sweet/domain/gift/controller/GiftApi.java
@@ -1,0 +1,7 @@
+package org.sopt.sweet.domain.gift.controller;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "선물", description = "선물 관련 API")
+public interface GiftApi {
+}

--- a/src/main/java/org/sopt/sweet/domain/gift/controller/GiftController.java
+++ b/src/main/java/org/sopt/sweet/domain/gift/controller/GiftController.java
@@ -5,5 +5,5 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RequestMapping("/api/gift")
 @RestController
-public class GiftController {
+public class GiftController implements GiftApi{
 }

--- a/src/main/java/org/sopt/sweet/domain/gifter/controller/GifterApi.java
+++ b/src/main/java/org/sopt/sweet/domain/gifter/controller/GifterApi.java
@@ -1,0 +1,7 @@
+package org.sopt.sweet.domain.gifter.controller;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "선물 모임", description = "선물 모임 관련 API")
+public interface GifterApi {
+}

--- a/src/main/java/org/sopt/sweet/domain/gifter/controller/GifterController.java
+++ b/src/main/java/org/sopt/sweet/domain/gifter/controller/GifterController.java
@@ -5,5 +5,5 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RequestMapping("/api/gifter")
 @RestController
-public class GifterController {
+public class GifterController implements GifterApi {
 }

--- a/src/main/java/org/sopt/sweet/domain/member/controller/MemberApi.java
+++ b/src/main/java/org/sopt/sweet/domain/member/controller/MemberApi.java
@@ -1,0 +1,26 @@
+package org.sopt.sweet.domain.member.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.sopt.sweet.global.common.SuccessResponse;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "회원", description = "회원 관련 API")
+public interface MemberApi {
+
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "200"),
+                    @ApiResponse(responseCode = "404", content = @Content)
+            }
+    )
+    @Operation(summary = "프로필을 조회")
+    ResponseEntity<SuccessResponse<?>> testSwagger(
+//            @Parameter(description = "파라미터는 이런 식으로 사용", required = true) Long id
+    );
+
+}

--- a/src/main/java/org/sopt/sweet/domain/member/controller/MemberController.java
+++ b/src/main/java/org/sopt/sweet/domain/member/controller/MemberController.java
@@ -1,10 +1,18 @@
 package org.sopt.sweet.domain.member.controller;
 
+import org.sopt.sweet.global.common.SuccessResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequestMapping("/api/member")
 @RestController
-public class MemberController {
+public class MemberController implements MemberApi{
 
+    @GetMapping(path = "/test")
+    public ResponseEntity<SuccessResponse<?>> testSwagger() {
+        String response = "Sweet little kitty";
+        return SuccessResponse.ok(response);
+    }
 }

--- a/src/main/java/org/sopt/sweet/domain/product/controller/ProductApi.java
+++ b/src/main/java/org/sopt/sweet/domain/product/controller/ProductApi.java
@@ -1,0 +1,7 @@
+package org.sopt.sweet.domain.product.controller;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "추천 상품", description = "추천 상품 관련 API")
+public interface ProductApi {
+}

--- a/src/main/java/org/sopt/sweet/domain/product/controller/ProductController.java
+++ b/src/main/java/org/sopt/sweet/domain/product/controller/ProductController.java
@@ -5,5 +5,5 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RequestMapping("/api/product")
 @RestController
-public class ProductController {
+public class ProductController implements ProductApi{
 }

--- a/src/main/java/org/sopt/sweet/global/common/HealthCheckApiController.java
+++ b/src/main/java/org/sopt/sweet/global/common/HealthCheckApiController.java
@@ -1,10 +1,13 @@
 package org.sopt.sweet.global.common;
 
+import io.swagger.v3.oas.annotations.Hidden;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 public class HealthCheckApiController {
+
+    @Hidden
     @RequestMapping("/")
     public String SweetServer() {
         return "Sweet little kitty!";

--- a/src/main/java/org/sopt/sweet/global/config/SwaggerConfig.java
+++ b/src/main/java/org/sopt/sweet/global/config/SwaggerConfig.java
@@ -16,9 +16,9 @@ public class SwaggerConfig {
     @Bean
     public OpenAPI openAPI(){
         Info info = new Info()
-                .title("DODAY API Document")
-                .version("v0.1")
-                .description("doday API 명세서입니다.");
+                .title("Sweet API Document")
+                .version("v1.0")
+                .description("sweet API 명세서입니다.");
 
         SecurityScheme securityScheme = new SecurityScheme()
                 .name("Authorization")

--- a/src/main/java/org/sopt/sweet/global/config/SwaggerConfig.java
+++ b/src/main/java/org/sopt/sweet/global/config/SwaggerConfig.java
@@ -6,19 +6,20 @@ import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import io.swagger.v3.oas.models.servers.Server;
+
 import static io.swagger.v3.oas.models.security.SecurityScheme.In.HEADER;
 
 @Configuration
 public class SwaggerConfig {
 
     @Bean
-    public OpenAPI publicApi() {
-        // 기본적인 정보 생성
+    public OpenAPI openAPI(){
         Info info = new Info()
-                .title("Sweet")
-                .description("Sweet의 API 명세서입니다.")
-                .version("v1");
-        // jwt에 대한 SecurityScheme 설정, Swagger-ui에서 token 인증이 가능=
+                .title("DODAY API Document")
+                .version("v0.1")
+                .description("doday API 명세서입니다.");
+
         SecurityScheme securityScheme = new SecurityScheme()
                 .name("Authorization")
                 .type(SecurityScheme.Type.HTTP)
@@ -29,7 +30,9 @@ public class SwaggerConfig {
         Components components = new Components().addSecuritySchemes("token", securityScheme);
 
         return new OpenAPI()
+                .addServersItem(new Server().url("/"))
                 .info(info)
                 .components(components);
     }
+
 }

--- a/src/main/java/org/sopt/sweet/global/config/SwaggerConfig.java
+++ b/src/main/java/org/sopt/sweet/global/config/SwaggerConfig.java
@@ -1,0 +1,35 @@
+package org.sopt.sweet.global.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import static io.swagger.v3.oas.models.security.SecurityScheme.In.HEADER;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI publicApi() {
+        // 기본적인 정보 생성
+        Info info = new Info()
+                .title("Sweet")
+                .description("Sweet의 API 명세서입니다.")
+                .version("v1");
+        // jwt에 대한 SecurityScheme 설정, Swagger-ui에서 token 인증이 가능=
+        SecurityScheme securityScheme = new SecurityScheme()
+                .name("Authorization")
+                .type(SecurityScheme.Type.HTTP)
+                .in(HEADER)
+                .bearerFormat("JWT")
+                .scheme("Bearer");
+
+        Components components = new Components().addSecuritySchemes("token", securityScheme);
+
+        return new OpenAPI()
+                .info(info)
+                .components(components);
+    }
+}

--- a/src/main/java/org/sopt/sweet/global/config/auth/SecurityConfig.java
+++ b/src/main/java/org/sopt/sweet/global/config/auth/SecurityConfig.java
@@ -24,18 +24,18 @@ public class SecurityConfig {
     private final JwtProvider jwtProvider;
 
     private static final String[] whiteList = {"/",
-            "/swagger-ui/index.html",
-            "/swagger-ui/swagger-ui-standalone-preset.js",
-            "/swagger-ui/swagger-initializer.js",
-            "/swagger-ui/swagger-ui-bundle.js",
-            "/swagger-ui/swagger-ui.css",
-            "/swagger-ui/index.css",
-            "/swagger-ui/favicon-32x32.png",
-            "/swagger-ui/favicon-16x16.png",
-            "/api-docs/json/swagger-config",
-            "/api-docs/json",
+            /* swagger v2 */
+            "/v2/api-docs",
+            "/swagger-resources",
+            "/swagger-resources/**",
+            "/configuration/ui",
+            "/configuration/security",
+            "/swagger-ui.html",
+            "/webjars/**",
+            /* swagger v3 */
             "/v3/api-docs/**",
-            "/api/member/test"
+            "/swagger-ui/**",
+            "api/member/test"
             };
 
     @Bean

--- a/src/main/java/org/sopt/sweet/global/config/auth/SecurityConfig.java
+++ b/src/main/java/org/sopt/sweet/global/config/auth/SecurityConfig.java
@@ -35,7 +35,8 @@ public class SecurityConfig {
             /* swagger v3 */
             "/v3/api-docs/**",
             "/swagger-ui/**",
-            "api/member/test"
+            "api/member/test",
+            "api/v1/docs"
             };
 
     @Bean

--- a/src/main/java/org/sopt/sweet/global/config/auth/SecurityConfig.java
+++ b/src/main/java/org/sopt/sweet/global/config/auth/SecurityConfig.java
@@ -23,7 +23,20 @@ public class SecurityConfig {
     private final CorsConfig corsConfig;
     private final JwtProvider jwtProvider;
 
-    private static final String[] whiteList = {"/"};
+    private static final String[] whiteList = {"/",
+            "/swagger-ui/index.html",
+            "/swagger-ui/swagger-ui-standalone-preset.js",
+            "/swagger-ui/swagger-initializer.js",
+            "/swagger-ui/swagger-ui-bundle.js",
+            "/swagger-ui/swagger-ui.css",
+            "/swagger-ui/index.css",
+            "/swagger-ui/favicon-32x32.png",
+            "/swagger-ui/favicon-16x16.png",
+            "/api-docs/json/swagger-config",
+            "/api-docs/json",
+            "/v3/api-docs/**",
+            "/api/member/test"
+            };
 
     @Bean
     public WebSecurityCustomizer webSecurityCustomizer() {

--- a/src/main/java/org/sopt/sweet/global/config/auth/SecurityConfig.java
+++ b/src/main/java/org/sopt/sweet/global/config/auth/SecurityConfig.java
@@ -37,7 +37,7 @@ public class SecurityConfig {
             "/swagger-ui/**",
             "api/member/test",
             "api/v1/docs",
-            "api/v1/swagger-ui/index.html"
+            "api/v1/swagger-ui/**"
             };
 
     @Bean

--- a/src/main/java/org/sopt/sweet/global/config/auth/SecurityConfig.java
+++ b/src/main/java/org/sopt/sweet/global/config/auth/SecurityConfig.java
@@ -36,7 +36,8 @@ public class SecurityConfig {
             "/v3/api-docs/**",
             "/swagger-ui/**",
             "api/member/test",
-            "api/v1/docs"
+            "api/v1/docs",
+            "api/v1/swagger-ui/index.html"
             };
 
     @Bean


### PR DESCRIPTION
## Related Issue 🍫

- close : #7 

## Summary 🍪

- 스웨거 연동
- 관련 설정 파일 추가
- 각 도메인의 swagger 인터페이스 생성
- controller를 interface의 구현체로 수정

## Before i request PR review 🍰
1. 예시 코드로 Member 도메인에 테스트 API 생성해두었습니다. 코드 보시면서 이렇게 쓰는 거구나~ 하시면 될 거 같아요!
2. 로컬은 http://localhost:8080/api/v1/docs, 서버는 https://sopt-sweet.store/api/v1/docs 로 확인!
3. applicaton.yml 변경 있습니다!
