### PR TITLE
[feat] 선물방 정보 관련 기능 구현

### DIFF
--- a/src/main/java/org/sopt/sweet/domain/gift/repository/GiftRepository.java
+++ b/src/main/java/org/sopt/sweet/domain/gift/repository/GiftRepository.java
@@ -3,11 +3,18 @@ package org.sopt.sweet.domain.gift.repository;
 import org.sopt.sweet.domain.gift.entity.Gift;
 import org.sopt.sweet.domain.member.entity.Member;
 import org.sopt.sweet.domain.room.entity.Room;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface GiftRepository extends JpaRepository<Gift, Long> {
     long countByRoomAndMember(Room room, Member member);
+
     List<Gift> findByRoomAndMember(Room room, Member member);
+
+    @Query("SELECT g FROM Gift g WHERE g.room = :room AND g.member <> :member ORDER BY g.id DESC")
+    List<Gift> findLatestGiftsByRoomAndNotMember(@Param("room") Room room, @Param("member") Member member, Pageable pageable);
 }

--- a/src/main/java/org/sopt/sweet/domain/gift/service/GiftService.java
+++ b/src/main/java/org/sopt/sweet/domain/gift/service/GiftService.java
@@ -19,6 +19,7 @@ import org.sopt.sweet.global.error.exception.ForbiddenException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -40,6 +41,7 @@ public class GiftService {
         Room room = findRoomByIdOrThrow(createGiftRequestDto.roomId());
         checkRoomMemberNotExists(room, member);
         checkGiftCountNotExceeded(room, member);
+        checkTournamentStartDatePassed(room);
         Gift gift = buildGift(member, room, createGiftRequestDto);
         giftRepository.save(gift);
     }
@@ -76,6 +78,14 @@ public class GiftService {
         return gifts.stream()
                 .map(gift -> MyGiftDto.of(gift.getId(), gift.getImageUrl(), gift.getName(), gift.getCost()))
                 .collect(Collectors.toList());
+    }
+
+    private void checkTournamentStartDatePassed(Room room) {
+        LocalDateTime tournamentStartDate = room.getTournamentStartDate();
+        LocalDateTime currentDateTime = LocalDateTime.now();
+        if (currentDateTime.isAfter(tournamentStartDate)) {
+            throw new BusinessException(TOURNAMENT_START_DATE_PASSED);
+        }
     }
 
     private void checkGiftCountNotExceeded(Room room, Member member) {

--- a/src/main/java/org/sopt/sweet/domain/product/repository/ProductRepository.java
+++ b/src/main/java/org/sopt/sweet/domain/product/repository/ProductRepository.java
@@ -2,6 +2,12 @@ package org.sopt.sweet.domain.product.repository;
 
 import org.sopt.sweet.domain.product.entity.Product;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface ProductRepository extends JpaRepository<Product, Long> {
+    @Query(value = "SELECT p FROM Product p ORDER BY RAND() LIMIT :limit")
+    List<Product> findRandomProducts(@Param("limit") int limit);
 }

--- a/src/main/java/org/sopt/sweet/domain/room/controller/RoomApi.java
+++ b/src/main/java/org/sopt/sweet/domain/room/controller/RoomApi.java
@@ -81,6 +81,32 @@ public interface RoomApi {
                     example = "12345"
             ) @UserId Long userId,
             @Valid @RequestBody JoinRoomRequestDto joinRoomRequestDto
-            );
+    );
+
+    @Operation(
+            summary = "선물방 메인 조회 API",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(implementation = SuccessResponse.class)
+                            )
+                    )
+            },
+            security = @SecurityRequirement(name = "token")
+    )
+    ResponseEntity<SuccessResponse<?>> getRoomMainInfo(
+            @Parameter(
+                    description = "authorization token에서 얻은 userId, 임의입력하면 대체됩니다.",
+                    required = true,
+                    example = "12345"
+            ) @UserId Long userId,
+            @Parameter(
+                    description = "room 고유 id",
+                    required = true,
+                    example = "1"
+            ) @PathVariable Long roomId
+    );
 
 }

--- a/src/main/java/org/sopt/sweet/domain/room/controller/RoomApi.java
+++ b/src/main/java/org/sopt/sweet/domain/room/controller/RoomApi.java
@@ -109,4 +109,30 @@ public interface RoomApi {
             ) @PathVariable Long roomId
     );
 
+    @Operation(
+            summary = "선물방 설정 편집 조회 API",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(implementation = SuccessResponse.class)
+                            )
+                    )
+            },
+            security = @SecurityRequirement(name = "token")
+    )
+    ResponseEntity<SuccessResponse<?>> getRoomDetailInfo(
+            @Parameter(
+                    description = "authorization token에서 얻은 userId, 임의입력하면 대체됩니다.",
+                    required = true,
+                    example = "12345"
+            ) @UserId Long userId,
+            @Parameter(
+                    description = "room 고유 id",
+                    required = true,
+                    example = "1"
+            ) @PathVariable Long roomId
+    );
+
 }

--- a/src/main/java/org/sopt/sweet/domain/room/controller/RoomController.java
+++ b/src/main/java/org/sopt/sweet/domain/room/controller/RoomController.java
@@ -3,10 +3,7 @@ package org.sopt.sweet.domain.room.controller;
 import lombok.RequiredArgsConstructor;
 import org.sopt.sweet.domain.room.dto.request.CreateRoomRequestDto;
 import org.sopt.sweet.domain.room.dto.request.JoinRoomRequestDto;
-import org.sopt.sweet.domain.room.dto.response.CreateRoomResponseDto;
-import org.sopt.sweet.domain.room.dto.response.JoinRoomResponseDto;
-import org.sopt.sweet.domain.room.dto.response.RoomInviteResponseDto;
-import org.sopt.sweet.domain.room.dto.response.RoomMainResponseDto;
+import org.sopt.sweet.domain.room.dto.response.*;
 import org.sopt.sweet.domain.room.service.RoomService;
 import org.sopt.sweet.global.common.SuccessResponse;
 import org.sopt.sweet.global.config.auth.UserId;
@@ -42,5 +39,11 @@ public class RoomController implements RoomApi {
     public ResponseEntity<SuccessResponse<?>> getRoomMainInfo(@UserId Long userId, @PathVariable Long roomId){
         final RoomMainResponseDto roomMainResponseDto = roomService.getRoomMainInfo(userId, roomId);
         return SuccessResponse.ok(roomMainResponseDto);
+    }
+
+    @GetMapping("/detail/{roomId}")
+    public ResponseEntity<SuccessResponse<?>> getRoomDetailInfo(@UserId Long userId, @PathVariable Long roomId){
+        final RoomDetailResponseDto roomDetailResponseDto = roomService.getRoomDetailInfo(userId, roomId);
+        return SuccessResponse.ok(roomDetailResponseDto);
     }
 }

--- a/src/main/java/org/sopt/sweet/domain/room/controller/RoomController.java
+++ b/src/main/java/org/sopt/sweet/domain/room/controller/RoomController.java
@@ -6,6 +6,7 @@ import org.sopt.sweet.domain.room.dto.request.JoinRoomRequestDto;
 import org.sopt.sweet.domain.room.dto.response.CreateRoomResponseDto;
 import org.sopt.sweet.domain.room.dto.response.JoinRoomResponseDto;
 import org.sopt.sweet.domain.room.dto.response.RoomInviteResponseDto;
+import org.sopt.sweet.domain.room.dto.response.RoomMainResponseDto;
 import org.sopt.sweet.domain.room.service.RoomService;
 import org.sopt.sweet.global.common.SuccessResponse;
 import org.sopt.sweet.global.config.auth.UserId;
@@ -35,5 +36,11 @@ public class RoomController implements RoomApi {
     public ResponseEntity<SuccessResponse<?>> joinRoom(@UserId Long userId, @RequestBody JoinRoomRequestDto joinRoomRequestDto){
         final JoinRoomResponseDto joinRoomResponseDto = roomService.findAndJoinRoom(userId, joinRoomRequestDto);
         return SuccessResponse.ok(joinRoomResponseDto);
+    }
+
+    @GetMapping("/{roomId}")
+    public ResponseEntity<SuccessResponse<?>> getRoomMainInfo(@UserId Long userId, @PathVariable Long roomId){
+        final RoomMainResponseDto roomMainResponseDto = roomService.getRoomMainInfo(userId, roomId);
+        return SuccessResponse.ok(roomMainResponseDto);
     }
 }

--- a/src/main/java/org/sopt/sweet/domain/room/dto/response/HotProductGiftDto.java
+++ b/src/main/java/org/sopt/sweet/domain/room/dto/response/HotProductGiftDto.java
@@ -1,0 +1,22 @@
+package org.sopt.sweet.domain.room.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record HotProductGiftDto(
+        Long productId,
+        String imageUrl,
+        String name,
+        String url,
+        int cost
+) {
+    public static HotProductGiftDto of(Long productId, String imageUrl, String name, String url, int cost){
+        return HotProductGiftDto.builder()
+                .productId(productId)
+                .imageUrl(imageUrl)
+                .name(name)
+                .url(url)
+                .cost(cost)
+                .build();
+    }
+}

--- a/src/main/java/org/sopt/sweet/domain/room/dto/response/RoomDetailResponseDto.java
+++ b/src/main/java/org/sopt/sweet/domain/room/dto/response/RoomDetailResponseDto.java
@@ -1,0 +1,36 @@
+package org.sopt.sweet.domain.room.dto.response;
+
+import lombok.Builder;
+import org.sopt.sweet.domain.room.constant.TournamentDuration;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record RoomDetailResponseDto(
+        Long roomId,
+        String imageUrl,
+        String gifteeName,
+        int gifterNumber,
+        LocalDateTime deliveryDate,
+        LocalDateTime tournamentStartDate,
+        TournamentDuration tournamentDuration
+) {
+    public static RoomDetailResponseDto of(Long roomId,
+                                           String imageUrl,
+                                           String gifteeName,
+                                           int gifterNumber,
+                                           LocalDateTime deliveryDate,
+                                           LocalDateTime tournamentStartDate,
+                                           TournamentDuration tournamentDuration){
+        return RoomDetailResponseDto.builder()
+                .roomId(roomId)
+                .imageUrl(imageUrl)
+                .gifteeName(gifteeName)
+                .gifterNumber(gifterNumber)
+                .deliveryDate(deliveryDate)
+                .tournamentStartDate(tournamentStartDate)
+                .tournamentDuration(tournamentDuration)
+                .build();
+    }
+
+}

--- a/src/main/java/org/sopt/sweet/domain/room/dto/response/RoomFriendsGiftDto.java
+++ b/src/main/java/org/sopt/sweet/domain/room/dto/response/RoomFriendsGiftDto.java
@@ -1,0 +1,24 @@
+package org.sopt.sweet.domain.room.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record RoomFriendsGiftDto(
+        Long giftId,
+        String imageUrl,
+        String name,
+        String url,
+        int cost,
+        String ownerName
+) {
+    public static RoomFriendsGiftDto of(Long giftId, String imageUrl, String name, String url, int cost, String ownerName) {
+        return RoomFriendsGiftDto.builder()
+                .giftId(giftId)
+                .imageUrl(imageUrl)
+                .name(name)
+                .url(url)
+                .cost(cost)
+                .ownerName(ownerName)
+                .build();
+    }
+}

--- a/src/main/java/org/sopt/sweet/domain/room/dto/response/RoomMainResponseDto.java
+++ b/src/main/java/org/sopt/sweet/domain/room/dto/response/RoomMainResponseDto.java
@@ -1,0 +1,34 @@
+package org.sopt.sweet.domain.room.dto.response;
+
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.util.List;
+@Builder
+public record RoomMainResponseDto(
+        int gifterNumber,
+        String gifteeName,
+        String invitationCode,
+        LocalDateTime tournamentStartDate,
+        List<RoomMyGiftDto> roomMyGiftDtoList,
+        List<RoomFriendsGiftDto> roomFriendsGiftDtoList,
+        List<HotProductGiftDto> hotProductGiftDtoList
+) {
+    public static RoomMainResponseDto of(int gifterNumber,
+                                         String gifteeName,
+                                         String invitationCode,
+                                         LocalDateTime tournamentStartDate,
+                                         List<RoomMyGiftDto> roomMyGiftDtoList,
+                                         List<RoomFriendsGiftDto> roomFriendsGiftDtoList,
+                                         List<HotProductGiftDto> hotProductGiftDtoList){
+        return RoomMainResponseDto.builder()
+                .gifterNumber(gifterNumber)
+                .gifteeName(gifteeName)
+                .invitationCode(invitationCode)
+                .tournamentStartDate(tournamentStartDate)
+                .roomMyGiftDtoList(roomMyGiftDtoList)
+                .roomFriendsGiftDtoList(roomFriendsGiftDtoList)
+                .hotProductGiftDtoList(hotProductGiftDtoList)
+                .build();
+    }
+}

--- a/src/main/java/org/sopt/sweet/domain/room/dto/response/RoomMyGiftDto.java
+++ b/src/main/java/org/sopt/sweet/domain/room/dto/response/RoomMyGiftDto.java
@@ -1,0 +1,22 @@
+package org.sopt.sweet.domain.room.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record RoomMyGiftDto(
+        Long giftId,
+        String imageUrl,
+        String name,
+        String url,
+        int cost
+) {
+    public static RoomMyGiftDto of(Long giftId, String imageUrl, String name, String url, int cost){
+        return RoomMyGiftDto.builder()
+                .giftId(giftId)
+                .imageUrl(imageUrl)
+                .name(name)
+                .url(url)
+                .cost(cost)
+                .build();
+    }
+}

--- a/src/main/java/org/sopt/sweet/domain/room/service/RoomService.java
+++ b/src/main/java/org/sopt/sweet/domain/room/service/RoomService.java
@@ -98,13 +98,36 @@ public class RoomService {
         List<RoomMyGiftDto> roomMyGiftDtoList = buildRoomMyGiftDtoList(member, room);
         List<RoomFriendsGiftDto> roomFriendsGiftDtoList = buildRoomFriendsGiftDtoList(member, room);
         List<HotProductGiftDto> hotProductGiftDtoList = buildHotProductGiftDtoList();
-        return RoomMainResponseDto.of(room.getGifterNumber(),
+        return RoomMainResponseDto.of(
+                room.getGifterNumber(),
                 room.getGifteeName(),
                 room.getInvitationCode(),
                 room.getTournamentStartDate(),
                 roomMyGiftDtoList,
                 roomFriendsGiftDtoList,
                 hotProductGiftDtoList);
+    }
+
+    @Transactional(readOnly = true)
+    public RoomDetailResponseDto getRoomDetailInfo(Long memberId, Long roomId){
+        Member member = findMemberByIdOrThrow(memberId);
+        Room room = findByIdOrThrow(roomId);
+        checkRoomHost(member, room);
+        return RoomDetailResponseDto.of(
+                roomId,
+                room.getImageUrl(),
+                room.getGifteeName(),
+                room.getGifterNumber(),
+                room.getDeliveryDate(),
+                room.getTournamentStartDate(),
+                room.getTournamentDuration()
+        );
+    }
+
+    private void checkRoomHost(Member member, Room room){
+        if (!member.equals(room.getHost())) {
+            throw new ForbiddenException(ROOM_OWNER_MISMATCH);
+        }
     }
 
     private List<RoomMyGiftDto> buildRoomMyGiftDtoList(Member member, Room room) {

--- a/src/main/java/org/sopt/sweet/domain/room/service/RoomService.java
+++ b/src/main/java/org/sopt/sweet/domain/room/service/RoomService.java
@@ -1,24 +1,30 @@
 package org.sopt.sweet.domain.room.service;
 
 import lombok.RequiredArgsConstructor;
+import org.sopt.sweet.domain.gift.entity.Gift;
+import org.sopt.sweet.domain.gift.repository.GiftRepository;
 import org.sopt.sweet.domain.member.entity.Member;
 import org.sopt.sweet.domain.member.repository.MemberRepository;
+import org.sopt.sweet.domain.product.entity.Product;
+import org.sopt.sweet.domain.product.repository.ProductRepository;
 import org.sopt.sweet.domain.room.dto.request.CreateRoomRequestDto;
 import org.sopt.sweet.domain.room.dto.request.JoinRoomRequestDto;
-import org.sopt.sweet.domain.room.dto.response.CreateRoomResponseDto;
-import org.sopt.sweet.domain.room.dto.response.JoinRoomResponseDto;
-import org.sopt.sweet.domain.room.dto.response.RoomInviteResponseDto;
+import org.sopt.sweet.domain.room.dto.response.*;
 import org.sopt.sweet.domain.room.entity.Room;
 import org.sopt.sweet.domain.room.entity.RoomMember;
 import org.sopt.sweet.domain.room.repository.RoomMemberRepository;
 import org.sopt.sweet.domain.room.repository.RoomRepository;
 import org.sopt.sweet.global.error.exception.*;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.security.SecureRandom;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static org.sopt.sweet.global.error.ErrorCode.*;
 
@@ -30,6 +36,8 @@ public class RoomService {
     private final RoomRepository roomRepository;
     private final MemberRepository memberRepository;
     private final RoomMemberRepository roomMemberRepository;
+    private final GiftRepository giftRepository;
+    private final ProductRepository productRepository;
     private static final String CHARACTERS = "abcdefghijklmnopqrstuvwxyz0123456789";
     private static final int CODE_LENGTH = 6;
     private static final int MAX_GIFTER_NUMBER = 8;
@@ -71,7 +79,8 @@ public class RoomService {
                 room.getDeliveryDate(),
                 room.getTournamentStartDate(),
                 room.getTournamentDuration(),
-                room.getInvitationCode());
+                room.getInvitationCode()
+        );
     }
 
     public JoinRoomResponseDto findAndJoinRoom(Long memberId, JoinRoomRequestDto joinRoomRequestDto) {
@@ -79,6 +88,63 @@ public class RoomService {
         Room room = findByInvitationOrThrow(joinRoomRequestDto.invitationCode());
         joinRoom(member, room);
         return JoinRoomResponseDto.of(room.getId());
+    }
+
+    @Transactional(readOnly = true)
+    public RoomMainResponseDto getRoomMainInfo(Long memberId, Long roomId) {
+        Member member = findMemberByIdOrThrow(memberId);
+        Room room = findByIdOrThrow(roomId);
+        checkRoomMemberNotExists(room, member);
+        List<RoomMyGiftDto> roomMyGiftDtoList = buildRoomMyGiftDtoList(member, room);
+        List<RoomFriendsGiftDto> roomFriendsGiftDtoList = buildRoomFriendsGiftDtoList(member, room);
+        List<HotProductGiftDto> hotProductGiftDtoList = buildHotProductGiftDtoList();
+        return RoomMainResponseDto.of(room.getGifterNumber(),
+                room.getGifteeName(),
+                room.getInvitationCode(),
+                room.getTournamentStartDate(),
+                roomMyGiftDtoList,
+                roomFriendsGiftDtoList,
+                hotProductGiftDtoList);
+    }
+
+    private List<RoomMyGiftDto> buildRoomMyGiftDtoList(Member member, Room room) {
+        List<Gift> roomGifts = giftRepository.findByRoomAndMember(room, member);
+        return roomGifts.stream()
+                .map(gift -> RoomMyGiftDto.of(
+                        gift.getId(),
+                        gift.getImageUrl(),
+                        gift.getName(),
+                        gift.getUrl(),
+                        gift.getCost()
+                ))
+                .collect(Collectors.toList());
+    }
+
+    private List<RoomFriendsGiftDto> buildRoomFriendsGiftDtoList(Member member, Room room) {
+        List<Gift> roomGifts = giftRepository.findLatestGiftsByRoomAndNotMember(room, member, PageRequest.of(0, 5));
+        return roomGifts.stream()
+                .map(gift -> RoomFriendsGiftDto.of(
+                        gift.getId(),
+                        gift.getImageUrl(),
+                        gift.getName(),
+                        gift.getUrl(),
+                        gift.getCost(),
+                        gift.getMember().getNickName()
+                ))
+                .collect(Collectors.toList());
+    }
+
+    private List<HotProductGiftDto> buildHotProductGiftDtoList() {
+        List<Product> randomProducts = productRepository.findRandomProducts(5);
+        return randomProducts.stream()
+                .map(product -> HotProductGiftDto.of(
+                        product.getId(),
+                        product.getImageUrl(),
+                        product.getName(),
+                        product.getUrl(),
+                        product.getCost()
+                ))
+                .collect(Collectors.toList());
     }
 
     private void joinRoom(Member member, Room room) {
@@ -103,6 +169,12 @@ public class RoomService {
     private void checkRoomMemberExists(Room room, Member member) {
         if (isRoomMemberExists(room, member)) {
             throw new BusinessException(MEMBER_ALREADY_EXISTS_ROOM);
+        }
+    }
+
+    private void checkRoomMemberNotExists(Room room, Member member) {
+        if (!isRoomMemberExists(room, member)) {
+            throw new BusinessException(MEMBER_NOT_IN_ROOM);
         }
     }
 

--- a/src/main/java/org/sopt/sweet/global/error/ErrorCode.java
+++ b/src/main/java/org/sopt/sweet/global/error/ErrorCode.java
@@ -36,6 +36,7 @@ public enum ErrorCode {
     FORBIDDEN(HttpStatus.FORBIDDEN, "리소스 접근 권한이 없습니다."),
     MEMBER_NOT_IN_ROOM(HttpStatus.FORBIDDEN, "해당 선물 방에 존재하지 않는 멤버입니다."),
     MEMBER_NOT_GIFT_OWNER(HttpStatus.FORBIDDEN, "해당 선물을 등록하지 않은 멤버입니다."),
+    ROOM_OWNER_MISMATCH(HttpStatus.FORBIDDEN, "해당 선물방의 개설자가 아닙니다."),
 
     /**
      * 404 Not Found

--- a/src/main/java/org/sopt/sweet/global/error/ErrorCode.java
+++ b/src/main/java/org/sopt/sweet/global/error/ErrorCode.java
@@ -16,6 +16,7 @@ public enum ErrorCode {
     MEMBER_NUMBER_EXCEEDED(HttpStatus.BAD_REQUEST, "해당 선물방의 최대 인원을 초과하였습니다."),
     INVITATION_CLOSED(HttpStatus.BAD_REQUEST, "초대가 마감되었습니다."),
     MEMBER_GIFT_COUNT_EXCEEDED(HttpStatus.BAD_REQUEST, "최대 선물 등록 개수를 초과하였습니다."),
+    TOURNAMENT_START_DATE_PASSED(HttpStatus.BAD_REQUEST, "토너먼트 시작 날짜가 지났습니다"),
 
     /**
      * 401 Unauthorized


### PR DESCRIPTION
## Related Issue 🍫

- close : #27 

## Summary 🍪
- 선물방 정보 홈 API (기본 정보, 내가 등록한 선물 정보, 친구가 등록한 선물 5개, 2030주목 선물 5개)
- 선물방 편집 화면에서 정보 조회 API
- 토너먼트 시작 날짜가 지나면 선물 추가 못하도록 예외처리 추가

## Before i request PR review 🍰

- 닫아둔 pr들도 한 번씩 확인해주세요~!
