### PR TITLE
[feat] 선물 토너먼트 리스트 API 구현

### DIFF
--- a/src/main/java/org/sopt/sweet/domain/gift/controller/GiftApi.java
+++ b/src/main/java/org/sopt/sweet/domain/gift/controller/GiftApi.java
@@ -83,4 +83,43 @@ public interface GiftApi {
             ) @UserId Long userId,
             @PathVariable Long giftId
     );
+
+
+    @Operation(
+            summary = "토너먼트 선물 리스트 조회 API",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "토너먼트 선물 목록 조회 성공",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(implementation = SuccessResponse.class)
+                            )
+                    ),
+                    @ApiResponse(
+                            responseCode = "404",
+                            description = "토너먼트나 사용자가 존재하지 않음",
+                            content = @Content
+                    ),
+                    @ApiResponse(
+                            responseCode = "403",
+                            description = "토너먼트 시작일이 지났거나 사용자가 방에 속해있지 않음",
+                            content = @Content
+                    )
+            },
+            security = @SecurityRequirement(name = "token")
+    )
+    ResponseEntity<SuccessResponse<?>> getTournamentGiftList(
+            @Parameter(
+                    description = "authorization token에서 얻은 userId, 임의입력하면 대체됩니다.",
+                    required = true,
+                    example = "12345"
+            ) @UserId Long userId,
+            @Parameter(
+                    description = "조회하려는 토너먼트가 진행 중인 방의 ID",
+                    required = true,
+                    example = "2"
+            ) @PathVariable Long roomId
+    );
+
 }

--- a/src/main/java/org/sopt/sweet/domain/gift/controller/GiftController.java
+++ b/src/main/java/org/sopt/sweet/domain/gift/controller/GiftController.java
@@ -4,11 +4,14 @@ import lombok.RequiredArgsConstructor;
 import org.sopt.sweet.domain.gift.dto.request.CreateGiftRequestDto;
 import org.sopt.sweet.domain.gift.dto.request.MyGiftsRequestDto;
 import org.sopt.sweet.domain.gift.dto.response.MyGiftsResponseDto;
+import org.sopt.sweet.domain.gift.dto.response.TournamentListsResponseDto;
 import org.sopt.sweet.domain.gift.service.GiftService;
 import org.sopt.sweet.global.common.SuccessResponse;
 import org.sopt.sweet.global.config.auth.UserId;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RequiredArgsConstructor
 @RequestMapping("/api/gift")
@@ -34,4 +37,13 @@ public class GiftController implements GiftApi {
         giftService.deleteMyGift(userId, giftId);
         return SuccessResponse.ok(null);
     }
+
+    @GetMapping("/tonermant/{roomId}")
+    public ResponseEntity<SuccessResponse<?>> getTournamentGiftList(@UserId Long userId,@PathVariable Long roomId) {
+        List<TournamentListsResponseDto> tournamentGiftList = giftService.getTournamentGiftList(roomId);
+        return SuccessResponse.ok(tournamentGiftList);
+    }
+
+
+
 }

--- a/src/main/java/org/sopt/sweet/domain/gift/dto/response/TournamentListsResponseDto.java
+++ b/src/main/java/org/sopt/sweet/domain/gift/dto/response/TournamentListsResponseDto.java
@@ -9,14 +9,16 @@ public record TournamentListsResponseDto(
         Long giftId,
         String imageUrl,
         String name,
-        int cost
+        int cost,
+        String url
 ) {
-    public static TournamentListsResponseDto of(Long giftId, String imageUrl, String name, int cost) {
+    public static TournamentListsResponseDto of(Long giftId, String imageUrl, String name, int cost, String url) {
         return TournamentListsResponseDto.builder()
                 .giftId(giftId)
                 .imageUrl(imageUrl)
                 .name(name)
                 .cost(cost)
+                .url(url)
                 .build();
     }
 

--- a/src/main/java/org/sopt/sweet/domain/gift/dto/response/TournamentListsResponseDto.java
+++ b/src/main/java/org/sopt/sweet/domain/gift/dto/response/TournamentListsResponseDto.java
@@ -1,0 +1,28 @@
+package org.sopt.sweet.domain.gift.dto.response;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record TournamentListsResponseDto(
+        Long giftId,
+        String imageUrl,
+        String name,
+        int cost
+) {
+    public static TournamentListsResponseDto of(Long giftId, String imageUrl, String name, int cost) {
+        return TournamentListsResponseDto.builder()
+                .giftId(giftId)
+                .imageUrl(imageUrl)
+                .name(name)
+                .cost(cost)
+                .build();
+    }
+
+    public static List<TournamentListsResponseDto> of(List<TournamentListsResponseDto> tournamentListsResponseDtoList) {
+        return tournamentListsResponseDtoList;
+    }
+}
+
+

--- a/src/main/java/org/sopt/sweet/domain/gift/repository/GiftRepository.java
+++ b/src/main/java/org/sopt/sweet/domain/gift/repository/GiftRepository.java
@@ -17,4 +17,6 @@ public interface GiftRepository extends JpaRepository<Gift, Long> {
 
     @Query("SELECT g FROM Gift g WHERE g.room = :room AND g.member <> :member ORDER BY g.id DESC")
     List<Gift> findLatestGiftsByRoomAndNotMember(@Param("room") Room room, @Param("member") Member member, Pageable pageable);
+
+    List<Gift> findByRoom(Room room);
 }

--- a/src/main/java/org/sopt/sweet/domain/gift/service/GiftService.java
+++ b/src/main/java/org/sopt/sweet/domain/gift/service/GiftService.java
@@ -5,6 +5,7 @@ import org.sopt.sweet.domain.gift.dto.request.CreateGiftRequestDto;
 import org.sopt.sweet.domain.gift.dto.request.MyGiftsRequestDto;
 import org.sopt.sweet.domain.gift.dto.response.MyGiftDto;
 import org.sopt.sweet.domain.gift.dto.response.MyGiftsResponseDto;
+import org.sopt.sweet.domain.gift.dto.response.TournamentListsResponseDto;
 import org.sopt.sweet.domain.gift.entity.Gift;
 import org.sopt.sweet.domain.gift.repository.GiftRepository;
 import org.sopt.sweet.domain.member.entity.Member;
@@ -122,8 +123,23 @@ public class GiftService {
                 .orElseThrow(() -> new EntityNotFoundException(ROOM_NOT_FOUND));
     }
 
-    private Gift findByIdOrThrow(Long giftId){
+    private Gift findByIdOrThrow(Long giftId) {
         return giftRepository.findById(giftId)
                 .orElseThrow(() -> new EntityNotFoundException(GIFT_NOT_FOUND));
     }
+
+
+    @Transactional(readOnly = true)
+    public List<TournamentListsResponseDto> getTournamentGiftList(Long roomId) {
+        Room room = findRoomByIdOrThrow(roomId);
+        List<Gift> gifts = giftRepository.findByRoom(room);
+        return mapGiftsToTournamentLists(gifts);
+    }
+
+    private List<TournamentListsResponseDto> mapGiftsToTournamentLists(List<Gift> gifts) {
+        return gifts.stream()
+                .map(gift -> TournamentListsResponseDto.of(gift.getId(), gift.getImageUrl(), gift.getName(), gift.getCost()))
+                .collect(Collectors.toList());
+    }
+
 }

--- a/src/main/java/org/sopt/sweet/domain/gift/service/GiftService.java
+++ b/src/main/java/org/sopt/sweet/domain/gift/service/GiftService.java
@@ -138,7 +138,7 @@ public class GiftService {
 
     private List<TournamentListsResponseDto> mapGiftsToTournamentLists(List<Gift> gifts) {
         return gifts.stream()
-                .map(gift -> TournamentListsResponseDto.of(gift.getId(), gift.getImageUrl(), gift.getName(), gift.getCost()))
+                .map(gift -> TournamentListsResponseDto.of(gift.getId(), gift.getImageUrl(), gift.getName(), gift.getCost(), gift.getUrl()))
                 .collect(Collectors.toList());
     }
 


### PR DESCRIPTION
## Related Issue 🍫

- close : #46 

## Summary 🍪

- 전체 상품 이름, 이미지, 가격, 링크 전달하는 선물 토너먼트 리스트 API 구현
<img width="1250" alt="스크린샷 2024-01-12 오후 3 30 26" src="https://github.com/SWEET-DEVELOPERS/sweet-server/assets/102026726/3ff7e857-fba8-444b-9ce3-7717ad03be20">


## Before i request PR review 🍰

- 프론트 요청 우선순위에 따라 선물 도메인(토너먼트 관련) 기능 구현 먼저 한 후 멤버 도메인 관련 구현 예정입니다.
