### PR TITLE
[feat] 토너먼트 랭킹 조회

### DIFF
--- a/src/main/java/org/sopt/sweet/domain/gift/controller/GiftApi.java
+++ b/src/main/java/org/sopt/sweet/domain/gift/controller/GiftApi.java
@@ -12,10 +12,14 @@ import jakarta.validation.Valid;
 import org.sopt.sweet.domain.gift.dto.request.CreateGiftRequestDto;
 import org.sopt.sweet.domain.gift.dto.request.MyGiftsRequestDto;
 import org.sopt.sweet.domain.gift.dto.request.TournamentScoreRequestDto;
+import org.sopt.sweet.domain.gift.dto.response.TournamentRankingResponseDto;
 import org.sopt.sweet.global.common.SuccessResponse;
 import org.sopt.sweet.global.config.auth.UserId;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+
+import java.util.List;
 
 @Tag(name = "선물", description = "선물 관련 API")
 public interface GiftApi {
@@ -180,5 +184,39 @@ public interface GiftApi {
                     required = true,
                     example = "2"
             ) @PathVariable Long roomId
+    );
+
+    @Operation(
+            summary = "토너먼트 랭킹 조회 API",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "토너먼트 랭킹 조회 성공",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(implementation = SuccessResponse.class)
+                            )
+                    ),
+                    @ApiResponse(
+                            responseCode = "404",
+                            description = "토너먼트나 사용자가 존재하지 않음",
+                            content = @Content
+                    ),
+                    @ApiResponse(
+                            responseCode = "403",
+                            description = "토너먼트 시작일이 지났거나 사용자가 방에 속해있지 않음",
+                            content = @Content
+                    )
+            },
+            security = @SecurityRequirement(name = "token")
+    )
+    @GetMapping("ranking/{roomId}")
+    ResponseEntity<SuccessResponse<?>> getRanking(
+            @Parameter(
+                    description = "authorization token에서 얻은 userId, 임의입력하면 대체됩니다.",
+                    required = true,
+                    example = "12345"
+            ) @UserId Long userId,
+            @PathVariable Long roomId
     );
 }

--- a/src/main/java/org/sopt/sweet/domain/gift/controller/GiftController.java
+++ b/src/main/java/org/sopt/sweet/domain/gift/controller/GiftController.java
@@ -7,6 +7,7 @@ import org.sopt.sweet.domain.gift.dto.request.TournamentScoreRequestDto;
 import org.sopt.sweet.domain.gift.dto.response.MyGiftsResponseDto;
 import org.sopt.sweet.domain.gift.dto.response.TournamentListsResponseDto;
 import org.sopt.sweet.domain.gift.dto.response.TournamentInfoDto;
+import org.sopt.sweet.domain.gift.dto.response.TournamentRankingResponseDto;
 import org.sopt.sweet.domain.gift.service.GiftService;
 import org.sopt.sweet.global.common.SuccessResponse;
 import org.sopt.sweet.global.config.auth.UserId;
@@ -57,6 +58,16 @@ public class GiftController implements GiftApi {
         final TournamentInfoDto tournamentInfo = giftService.getTournamentInfo(userId, roomId);
         return SuccessResponse.ok(tournamentInfo);
     }
+
+    @GetMapping("ranking/{roomId}")
+    public ResponseEntity<SuccessResponse<?>> getRanking(@UserId Long userId, @PathVariable Long roomId) {
+        final List<TournamentRankingResponseDto> ranking = giftService.getTournamentRanking(roomId);
+        return SuccessResponse.ok(ranking);
+    }
+
+
+
+
 
 
 

--- a/src/main/java/org/sopt/sweet/domain/gift/dto/response/TournamentRankingResponseDto.java
+++ b/src/main/java/org/sopt/sweet/domain/gift/dto/response/TournamentRankingResponseDto.java
@@ -1,0 +1,27 @@
+package org.sopt.sweet.domain.gift.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record TournamentRankingResponseDto(
+        Long ranking,
+        Long giftId,
+        String imageUrl,
+        String name,
+        int cost,
+        String url
+
+) {
+
+    public static TournamentRankingResponseDto of(  Long ranking,Long giftId, String imageUrl, String name, int cost, String url) {
+        return TournamentRankingResponseDto.builder()
+                .ranking(ranking)
+                .giftId(giftId)
+                .imageUrl(imageUrl)
+                .name(name)
+                .cost(cost)
+                .url(url)
+                .build();
+    }
+
+}

--- a/src/main/java/org/sopt/sweet/domain/gift/repository/GiftRepository.java
+++ b/src/main/java/org/sopt/sweet/domain/gift/repository/GiftRepository.java
@@ -20,5 +20,5 @@ public interface GiftRepository extends JpaRepository<Gift, Long> {
     List<Gift> findLatestGiftsByRoomAndNotMember(@Param("room") Room room, @Param("member") Member member, Pageable pageable);
 
     List<Gift> findByRoom(Room room);
-
+    List<Gift> findByRoomOrderByScoreDesc(Room room);
 }

--- a/src/main/java/org/sopt/sweet/domain/gift/service/GiftService.java
+++ b/src/main/java/org/sopt/sweet/domain/gift/service/GiftService.java
@@ -4,10 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.sopt.sweet.domain.gift.dto.request.CreateGiftRequestDto;
 import org.sopt.sweet.domain.gift.dto.request.MyGiftsRequestDto;
 import org.sopt.sweet.domain.gift.dto.request.TournamentScoreRequestDto;
-import org.sopt.sweet.domain.gift.dto.response.MyGiftDto;
-import org.sopt.sweet.domain.gift.dto.response.MyGiftsResponseDto;
-import org.sopt.sweet.domain.gift.dto.response.TournamentListsResponseDto;
-import org.sopt.sweet.domain.gift.dto.response.TournamentInfoDto;
+import org.sopt.sweet.domain.gift.dto.response.*;
 import org.sopt.sweet.domain.gift.entity.Gift;
 import org.sopt.sweet.domain.gift.repository.GiftRepository;
 import org.sopt.sweet.domain.member.entity.Member;
@@ -24,6 +21,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -40,7 +38,7 @@ public class GiftService {
     private final RoomMemberRepository roomMemberRepository;
     private static final int MAX_GIFT_COUNT = 2;
     private static final int FIRST_PLACE_SCORE = 10;
-    private static final int SECOND_PLACE_SCORE= 5;
+    private static final int SECOND_PLACE_SCORE = 5;
 
     public void createNewGift(Long memberId, CreateGiftRequestDto createGiftRequestDto) {
         Member member = findMemberByIdOrThrow(memberId);
@@ -191,6 +189,39 @@ public class GiftService {
     }
 
 
+    public List<TournamentRankingResponseDto> getTournamentRanking(Long roomId) {
+        Room room = findRoomByIdOrThrow(roomId);
+
+        List<Gift> gifts = giftRepository.findByRoomOrderByScoreDesc(room);
+        List<TournamentRankingResponseDto> rankingResponse = mapGiftsToTournamentRanking(gifts);
+        return rankingResponse;
+    }
+
+    private List<TournamentRankingResponseDto> mapGiftsToTournamentRanking(List<Gift> gifts) {
+        List<TournamentRankingResponseDto> rankingResponse = new ArrayList<>();
+        int rank = 0;
+        int currentScore = Integer.MAX_VALUE;
+
+        for (Gift gift : gifts) {
+            int giftScore = gift.getScore();
+            if (giftScore < currentScore) {
+                rank++;
+            }
+
+            rankingResponse.add(TournamentRankingResponseDto.of(
+                    (long) rank,
+                    gift.getId(),
+                    gift.getImageUrl(),
+                    gift.getName(),
+                    gift.getCost(),
+                    gift.getUrl()
+            ));
+
+            currentScore = giftScore;
+        }
+
+        return rankingResponse;
+    }
 
 
 }


### PR DESCRIPTION
## Related Issue 🍫

- close : #49 

## Summary 🍪

- 토너먼트 랭킹 조회 API 구현
- 동점 시 동일 랭킹 적용했습니다.
<img width="1275" alt="스크린샷 2024-01-13 오전 1 04 05" src="https://github.com/SWEET-DEVELOPERS/sweet-server/assets/102026726/e340d6ca-089e-482d-9295-8b4b74ddc311">

## Before i request PR review 🍰
