### PR TITLE
[feat] 친구가 등록한 선물 조회 API 구현

### DIFF
--- a/src/main/java/org/sopt/sweet/domain/gift/controller/GiftApi.java
+++ b/src/main/java/org/sopt/sweet/domain/gift/controller/GiftApi.java
@@ -2,6 +2,7 @@ package org.sopt.sweet.domain.gift.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
@@ -12,14 +13,13 @@ import jakarta.validation.Valid;
 import org.sopt.sweet.domain.gift.dto.request.CreateGiftRequestDto;
 import org.sopt.sweet.domain.gift.dto.request.MyGiftsRequestDto;
 import org.sopt.sweet.domain.gift.dto.request.TournamentScoreRequestDto;
-import org.sopt.sweet.domain.gift.dto.response.TournamentRankingResponseDto;
 import org.sopt.sweet.global.common.SuccessResponse;
 import org.sopt.sweet.global.config.auth.UserId;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 
-import java.util.List;
+import java.util.Map;
 
 @Tag(name = "선물", description = "선물 관련 API")
 public interface GiftApi {
@@ -147,7 +147,7 @@ public interface GiftApi {
                     example = "12345"
             ) @UserId Long userId,
             @Valid @RequestBody TournamentScoreRequestDto tournamentScoreRequestDto
-            );
+    );
 
 
     @Operation(
@@ -194,7 +194,7 @@ public interface GiftApi {
                             description = "토너먼트 랭킹 조회 성공",
                             content = @Content(
                                     mediaType = "application/json",
-                                    schema = @Schema(implementation = SuccessResponse.class)
+                                    array = @ArraySchema(schema = @Schema(implementation = SuccessResponse.class))
                             )
                     ),
                     @ApiResponse(
@@ -219,4 +219,43 @@ public interface GiftApi {
             ) @UserId Long userId,
             @PathVariable Long roomId
     );
+
+    @Operation(
+            summary = "친구들이 등록한 선물 조회 API",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "친구들이 등록한 선물 조회 성공",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(implementation = SuccessResponse.class)
+                            )
+                    ),
+                    @ApiResponse(
+                            responseCode = "404",
+                            description = "사용자 또는 방이 존재하지 않음",
+                            content = @Content
+                    ),
+                    @ApiResponse(
+                            responseCode = "403",
+                            description = "사용자가 방에 속해있지 않음",
+                            content = @Content
+                    )
+            },
+            security = @SecurityRequirement(name = "token")
+    )
+    @GetMapping("/friend/{roomId}")
+    ResponseEntity<SuccessResponse<?>> getFriendGift(
+            @Parameter(
+                    description = "authorization token에서 얻은 userId, 임의입력하면 대체됩니다.",
+                    required = true,
+                    example = "12345"
+            ) @UserId Long userId,
+            @Parameter(
+                    description = "방 ID",
+                    required = true,
+                    example = "2"
+            ) @PathVariable Long roomId
+    );
+
 }

--- a/src/main/java/org/sopt/sweet/domain/gift/controller/GiftController.java
+++ b/src/main/java/org/sopt/sweet/domain/gift/controller/GiftController.java
@@ -4,17 +4,17 @@ import lombok.RequiredArgsConstructor;
 import org.sopt.sweet.domain.gift.dto.request.CreateGiftRequestDto;
 import org.sopt.sweet.domain.gift.dto.request.MyGiftsRequestDto;
 import org.sopt.sweet.domain.gift.dto.request.TournamentScoreRequestDto;
-import org.sopt.sweet.domain.gift.dto.response.MyGiftsResponseDto;
-import org.sopt.sweet.domain.gift.dto.response.TournamentListsResponseDto;
-import org.sopt.sweet.domain.gift.dto.response.TournamentInfoDto;
-import org.sopt.sweet.domain.gift.dto.response.TournamentRankingResponseDto;
+import org.sopt.sweet.domain.gift.dto.response.*;
 import org.sopt.sweet.domain.gift.service.GiftService;
+import org.sopt.sweet.domain.room.entity.Room;
 import org.sopt.sweet.global.common.SuccessResponse;
 import org.sopt.sweet.global.config.auth.UserId;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @RequiredArgsConstructor
 @RequestMapping("/api/gift")
@@ -65,6 +65,17 @@ public class GiftController implements GiftApi {
         return SuccessResponse.ok(ranking);
     }
 
+    @GetMapping("/friend/{roomId}")
+    public ResponseEntity<SuccessResponse<?>> getFriendGift(@UserId Long userId, @PathVariable Long roomId) {
+        TournamentStartDateResponseDto tournamentStartDate = giftService.getTournamentStartDate(roomId);
+        final List<FriendGiftDto> friendGiftList = giftService.getFriendGift(userId, roomId);
+
+        Map<String, Object> result = new HashMap<>();
+        result.put("tournamentStartDate", tournamentStartDate);
+        result.put("friendGiftDto", friendGiftList);
+        return SuccessResponse.ok(result);
+
+    }
 
 
 

--- a/src/main/java/org/sopt/sweet/domain/gift/dto/response/FriendGiftDto.java
+++ b/src/main/java/org/sopt/sweet/domain/gift/dto/response/FriendGiftDto.java
@@ -1,0 +1,30 @@
+package org.sopt.sweet.domain.gift.dto.response;
+
+import lombok.Builder;
+import org.sopt.sweet.domain.gift.dto.request.TournamentScoreRequestDto;
+import org.sopt.sweet.domain.gift.entity.Gift;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record FriendGiftDto(
+        Long giftId,
+        String imageUrl,
+        String name,
+        int cost,
+        String url,
+        LocalDateTime createDate
+) {
+
+    public static FriendGiftDto of(Gift gift) {
+        return new FriendGiftDto(
+                gift.getId(),
+                gift.getImageUrl(),
+                gift.getName(),
+                gift.getCost(),
+                gift.getUrl(),
+                gift.getCreateDate()
+        );
+    }
+
+}

--- a/src/main/java/org/sopt/sweet/domain/gift/dto/response/TournamentStartDateResponseDto.java
+++ b/src/main/java/org/sopt/sweet/domain/gift/dto/response/TournamentStartDateResponseDto.java
@@ -1,0 +1,8 @@
+package org.sopt.sweet.domain.gift.dto.response;
+
+import java.time.LocalDateTime;
+
+public record TournamentStartDateResponseDto(
+        LocalDateTime tournamentStartDate
+) {
+}

--- a/src/main/java/org/sopt/sweet/domain/gift/entity/Gift.java
+++ b/src/main/java/org/sopt/sweet/domain/gift/entity/Gift.java
@@ -4,12 +4,13 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.sopt.sweet.domain.room.entity.Room;
 import org.sopt.sweet.domain.member.entity.Member;
+import org.sopt.sweet.global.common.BaseTimeEntity;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "gift")
 @Entity
-public class Gift {
+public class Gift extends BaseTimeEntity {
 
     private static final int DEFAULT_SCORE = 0;
 

--- a/src/main/java/org/sopt/sweet/domain/gift/repository/GiftRepository.java
+++ b/src/main/java/org/sopt/sweet/domain/gift/repository/GiftRepository.java
@@ -21,4 +21,6 @@ public interface GiftRepository extends JpaRepository<Gift, Long> {
 
     List<Gift> findByRoom(Room room);
     List<Gift> findByRoomOrderByScoreDesc(Room room);
+
+    List<Gift> findByRoomAndMemberNot(Room room, Member member);
 }

--- a/src/main/java/org/sopt/sweet/domain/gift/service/GiftService.java
+++ b/src/main/java/org/sopt/sweet/domain/gift/service/GiftService.java
@@ -22,6 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -223,5 +224,25 @@ public class GiftService {
         return rankingResponse;
     }
 
+    public List<FriendGiftDto> getFriendGift(Long memberId, Long roomId) {
+        Member member = findMemberByIdOrThrow(memberId);
+        Room room = findRoomByIdOrThrow(roomId);
+        checkRoomMemberNotExists(room, member);
+        List<Gift> gifts = giftRepository.findByRoomAndMemberNot(room, member);
+        return mapGiftsToFriendGiftDtoList(gifts);
+    }
 
+
+    private List<FriendGiftDto> mapGiftsToFriendGiftDtoList(List<Gift> gifts) {
+        return gifts.stream()
+                .sorted(Comparator.comparing(Gift::getCreateDate).reversed())
+                .map(gift -> FriendGiftDto.of(gift))
+                .collect(Collectors.toList());
+    }
+
+    public TournamentStartDateResponseDto getTournamentStartDate(Long roomId) {
+        Room room = findRoomByIdOrThrow(roomId);
+        LocalDateTime tournamentStartDate = room.getTournamentStartDate();
+        return new TournamentStartDateResponseDto(tournamentStartDate);
+    }
 }


### PR DESCRIPTION
## Related Issue 🍫

- close : #54 

## Summary 🍪

-친구가 등록한 선물 조회 API 구현
<img width="1324" alt="스크린샷 2024-01-13 오전 4 50 46" src="https://github.com/SWEET-DEVELOPERS/sweet-server/assets/102026726/7cf952e2-2fb2-4637-9a91-0c9b1dd82d2f">
726/ebb3f03c-8c1d-4e5d-bcd6-7b306730e89d">

## Before i request PR review 🍰

- 해당 룸의 토너먼트 시작일자와 본인 제외한 친구들 선물 리스트 최신순으로 조회하는 API입니다.
- 선물 최신순으로 조회하기 위해 Gift 엔티티에 Base엔티티 상속 추가했습니다.
- 등록한 선물 수정하는 기능은 아직 없어서 생성 일자인 createDate 기준으로 정렬했습니다.
  
