### PR TITLE
[feat] 종료된 선물방 API 구현

### DIFF
--- a/src/main/java/org/sopt/sweet/domain/member/controller/MemberApi.java
+++ b/src/main/java/org/sopt/sweet/domain/member/controller/MemberApi.java
@@ -3,11 +3,15 @@ package org.sopt.sweet.domain.member.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.sopt.sweet.global.common.SuccessResponse;
+import org.sopt.sweet.global.config.auth.UserId;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 
 @Tag(name = "회원", description = "회원 관련 API")
 public interface MemberApi {
@@ -31,6 +35,34 @@ public interface MemberApi {
     @Operation(summary = "토큰 임시 발급 API입니다. 로그인 생성 시 삭제할 예정입니다.")
     ResponseEntity<SuccessResponse<?>> getToken(
             @Parameter(description = "멤버 고유 id", required = true) Long memberId
+    );
+
+
+    @Operation(
+            summary = "종료된 선물방 조회 API",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(implementation = SuccessResponse.class)
+                            )
+                    ),
+                    @ApiResponse(
+                            responseCode = "401",
+                            description = "Unauthorized",
+                            content = @Content
+                    )
+            },
+            security = @SecurityRequirement(name = "token")
+    )
+    @GetMapping("closed-room")
+    public ResponseEntity<SuccessResponse<?>> getClosedRoom(
+            @Parameter(
+                    description = "Authorization token에서 얻은 userId, 임의입력하면 대체됩니다.",
+                    required = true,
+                    example = "12345"
+            ) @UserId Long userId
     );
 
 }

--- a/src/main/java/org/sopt/sweet/domain/member/controller/MemberController.java
+++ b/src/main/java/org/sopt/sweet/domain/member/controller/MemberController.java
@@ -1,11 +1,15 @@
 package org.sopt.sweet.domain.member.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.sopt.sweet.domain.member.dto.response.ClosedRoomResponseDto;
 import org.sopt.sweet.domain.member.dto.response.MemberTokenResponseDto;
 import org.sopt.sweet.domain.member.service.MemberService;
 import org.sopt.sweet.global.common.SuccessResponse;
+import org.sopt.sweet.global.config.auth.UserId;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RequiredArgsConstructor
 @RequestMapping("/api/member")
@@ -25,6 +29,12 @@ public class MemberController implements MemberApi{
     public ResponseEntity<SuccessResponse<?>> getToken(@PathVariable Long memberId){
         final MemberTokenResponseDto memberTokenResponseDto = memberService.getToken(memberId);
         return SuccessResponse.created(memberTokenResponseDto);
+    }
+
+    @GetMapping("closed-room")
+    public ResponseEntity<SuccessResponse<?>> getClosedRoom(@UserId Long userId) {
+        final List<ClosedRoomResponseDto> closedRoomResponseDto = memberService.getClosedRoom(userId);
+        return SuccessResponse.ok(closedRoomResponseDto);
     }
 
 

--- a/src/main/java/org/sopt/sweet/domain/member/dto/response/ClosedRoomResponseDto.java
+++ b/src/main/java/org/sopt/sweet/domain/member/dto/response/ClosedRoomResponseDto.java
@@ -1,0 +1,10 @@
+package org.sopt.sweet.domain.member.dto.response;
+
+public record ClosedRoomResponseDto(
+        Long roomId,
+        String imageUrl,
+        String gifteeName,
+        int gifterNumber
+) {
+
+}

--- a/src/main/java/org/sopt/sweet/domain/member/service/MemberService.java
+++ b/src/main/java/org/sopt/sweet/domain/member/service/MemberService.java
@@ -1,11 +1,21 @@
 package org.sopt.sweet.domain.member.service;
 
 import lombok.RequiredArgsConstructor;
+import org.sopt.sweet.domain.member.dto.response.ClosedRoomResponseDto;
 import org.sopt.sweet.domain.member.dto.response.MemberTokenResponseDto;
 import org.sopt.sweet.domain.member.repository.MemberRepository;
+import org.sopt.sweet.domain.room.entity.Room;
+import org.sopt.sweet.domain.room.entity.RoomMember;
+import org.sopt.sweet.domain.room.repository.RoomMemberRepository;
+import org.sopt.sweet.domain.room.repository.RoomRepository;
 import org.sopt.sweet.global.config.auth.jwt.JwtProvider;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Service
@@ -14,6 +24,8 @@ public class MemberService {
 
     private final JwtProvider jwtProvider;
     private final MemberRepository memberRepository;
+    private final RoomRepository roomRepository;
+    private final RoomMemberRepository roomMemberRepository;
 
     public MemberTokenResponseDto getToken(Long memberId) {
         String accessToken = issueNewAccessToken(memberId);
@@ -28,6 +40,30 @@ public class MemberService {
     private String issueNewRefreshToken(Long memberId) {
         return jwtProvider.getIssueToken(memberId, false);
     }
+
+
+    public List<ClosedRoomResponseDto> getClosedRoom(Long memberId) {
+        List<RoomMember> roomMembers = roomMemberRepository.findByMemberId(memberId);
+        System.out.println(memberId);
+        System.out.println("/"+ LocalDateTime.now());
+        List<ClosedRoomResponseDto> closedRooms = roomMembers.stream()
+                .map(RoomMember::getRoom)
+                .filter(room -> room.getDeliveryDate().isBefore(LocalDateTime.now()))
+                .sorted(Comparator.comparing(Room::getDeliveryDate).reversed())
+                .map(this::mapToClosedRoomResponseDto)
+                .collect(Collectors.toList());
+        return closedRooms;
+    }
+
+    private ClosedRoomResponseDto mapToClosedRoomResponseDto(Room room) {
+        return new ClosedRoomResponseDto(
+                room.getId(),
+                room.getImageUrl(),
+                room.getGifteeName(),
+                room.getGifterNumber()
+        );
+    }
+
 
 
 }

--- a/src/main/java/org/sopt/sweet/domain/room/entity/Room.java
+++ b/src/main/java/org/sopt/sweet/domain/room/entity/Room.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.sopt.sweet.domain.room.constant.TournamentDuration;
 import org.sopt.sweet.domain.member.entity.Member;
+import org.sopt.sweet.global.common.BaseTimeEntity;
 
 import java.time.LocalDateTime;
 
@@ -11,7 +12,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "room")
 @Entity
-public class Room {
+public class Room extends BaseTimeEntity {
 
     private static final int DEFAULT_NUMBER = 1;
 

--- a/src/main/java/org/sopt/sweet/domain/room/repository/RoomMemberRepository.java
+++ b/src/main/java/org/sopt/sweet/domain/room/repository/RoomMemberRepository.java
@@ -14,4 +14,6 @@ public interface RoomMemberRepository extends JpaRepository<RoomMember, Long> {
 
     int countByRoomIdAndTournamentParticipationIsTrue(Long roomId);
     RoomMember findByRoomIdAndMemberId(Long roomId, Long memberId);
+
+    List<RoomMember> findByMemberId(Long memberId);
 }


### PR DESCRIPTION
## Related Issue 🍫

- close : #57 

## Summary 🍪

- 종료된 선물방 API 구현
<img width="1271" alt="스크린샷 2024-01-13 오후 2 55 30" src="https://github.com/SWEET-DEVELOPERS/sweet-server/assets/102026726/beeef994-ba6c-4a7c-816f-0359e1f96307">

## Before i request PR review 🍰

- 선물방 선물 전달일(DeliveryDate)이 현재 시간보다 이전인 선물방에 대한 선물방 Id, 이미지, 이름, 참여자 수 조회 
- DeliveryDate가 최신순 부터 정렬(종료된 게 최근인 거 부터 정렬했습니당)
