### PR TITLE
[fix] 진행중인 선물방 조회 API response에 해당 멤버의 토너먼트 참여 여부 추가

### DIFF
--- a/src/main/java/org/sopt/sweet/domain/member/dto/response/ActiveRoomResponseDto.java
+++ b/src/main/java/org/sopt/sweet/domain/member/dto/response/ActiveRoomResponseDto.java
@@ -8,7 +8,8 @@ public record ActiveRoomResponseDto(
         String gifteeName,
         int gifterNumber,
         LocalDateTime tournamentStartDate,
-        Boolean isOwner
+        Boolean isOwner,
+        boolean tournamentParticipation
 
 ) {
 }

--- a/src/main/java/org/sopt/sweet/domain/member/service/MemberService.java
+++ b/src/main/java/org/sopt/sweet/domain/member/service/MemberService.java
@@ -86,8 +86,15 @@ public class MemberService {
                 room.getGifteeName(),
                 room.getGifterNumber(),
                 room.getTournamentStartDate(),
-                isOwner(memberId, room.getId())
+                isOwner(memberId, room.getId()),
+                getRoomMemberParticipation(room, memberId)
+
         );
+    }
+
+    private boolean getRoomMemberParticipation(Room room, Long memberId) {
+        Optional<RoomMember> roomMember = roomMemberRepository.findByMemberIdAndRoom(memberId, room);
+        return roomMember.map(RoomMember::isTournamentParticipation).orElse(false);
     }
 
     private LocalDateTime getRoomMemberCreationTime(Room room, Long memberId) {


### PR DESCRIPTION
## Related Issue 🍫

- close : #92 

## Summary 🍪

- 진행중인 선물방 조회 API response에 해당 멤버의 토너먼트 참여 여부 추가

## Before i request PR review 🍰

