### PR TITLE
[fix] 선물방 참여자 상세 조회 API 로직 분리

### DIFF
--- a/src/main/java/org/sopt/sweet/domain/room/controller/RoomController.java
+++ b/src/main/java/org/sopt/sweet/domain/room/controller/RoomController.java
@@ -67,6 +67,12 @@ public class RoomController implements RoomApi {
         return SuccessResponse.ok(roomMemberDetailDto);
     }
 
+    @GetMapping("/{roomId}/room-detail")
+    public ResponseEntity<SuccessResponse<?>> getRoom(@UserId Long userId, @PathVariable Long roomId) {
+        final RoomOwnerDetailDto roomOwnerDetailDto = roomService.getRoom(userId, roomId);
+        return SuccessResponse.ok(roomOwnerDetailDto);
+    }
+
     @DeleteMapping("/{roomId}/members/{memberId}")
     public ResponseEntity<SuccessResponse<?>> deleteRoomMember(@UserId Long userId, @PathVariable Long roomId, @PathVariable Long memberId) {
         roomService.deleteRoomMember(userId, roomId, memberId);

--- a/src/main/java/org/sopt/sweet/domain/room/dto/response/RoomMemberDetailDto.java
+++ b/src/main/java/org/sopt/sweet/domain/room/dto/response/RoomMemberDetailDto.java
@@ -6,14 +6,10 @@ import java.util.List;
 
 @Builder
 public record RoomMemberDetailDto(
-        RoomDto room,
-        OwnerDto owner,
         List<RoomMemberDto> members
 ) {
-    public static RoomMemberDetailDto of(RoomDto roomDto, OwnerDto ownerDto, List<RoomMemberDto> roomMemberDtoList) {
+    public static RoomMemberDetailDto of(List<RoomMemberDto> roomMemberDtoList) {
         return RoomMemberDetailDto.builder()
-                .room(roomDto)
-                .owner(ownerDto)
                 .members(roomMemberDtoList)
                 .build();
     }

--- a/src/main/java/org/sopt/sweet/domain/room/dto/response/RoomOwnerDetailDto.java
+++ b/src/main/java/org/sopt/sweet/domain/room/dto/response/RoomOwnerDetailDto.java
@@ -1,0 +1,16 @@
+package org.sopt.sweet.domain.room.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record RoomOwnerDetailDto(
+        RoomDto room,
+        OwnerDto owner
+) {
+    public static RoomOwnerDetailDto of(RoomDto roomDto, OwnerDto ownerDto) {
+        return RoomOwnerDetailDto.builder()
+                .room(roomDto)
+                .owner(ownerDto)
+                .build();
+    }
+}

--- a/src/main/java/org/sopt/sweet/domain/room/service/RoomService.java
+++ b/src/main/java/org/sopt/sweet/domain/room/service/RoomService.java
@@ -1,7 +1,6 @@
 package org.sopt.sweet.domain.room.service;
 
 import lombok.RequiredArgsConstructor;
-import org.hibernate.internal.util.collections.StandardStack;
 import org.sopt.sweet.domain.gift.entity.Gift;
 import org.sopt.sweet.domain.gift.repository.GiftRepository;
 import org.sopt.sweet.domain.member.entity.Member;
@@ -149,14 +148,19 @@ public class RoomService {
 
     @Transactional(readOnly = true)
     public RoomMemberDetailDto getRoomMembers(Long memberId, Long roomId) {
+        List<RoomMember> roomMembers = roomMemberRepository.findByRoomId(roomId);
+        List<RoomMemberDto> roomMemberDtoList = mapToRoomMemberDtoList(roomMembers);
+        return RoomMemberDetailDto.of(roomMemberDtoList);
+    }
+
+    @Transactional(readOnly = true)
+    public RoomOwnerDetailDto getRoom(Long memberId, Long roomId) {
         Member member = findMemberByIdOrThrow(memberId);
         Room room = findByIdOrThrow(roomId);
         checkRoomHost(member, room);
-        List<RoomMember> roomMembers = roomMemberRepository.findByRoomId(roomId);
-        List<RoomMemberDto> roomMemberDtoList = mapToRoomMemberDtoList(roomMembers);
         RoomDto roomDto = new RoomDto(room.getGifteeName(), room.getGifterNumber());
         OwnerDto ownerDto = new OwnerDto(room.getHost().getId(), room.getHost().getProfileImg(), room.getHost().getNickName());
-        return RoomMemberDetailDto.of(roomDto, ownerDto, roomMemberDtoList);
+        return RoomOwnerDetailDto.of(roomDto, ownerDto);
     }
 
     public void deleteRoomMember(Long memberId, Long roomId, Long deleteMemberId) {


### PR DESCRIPTION
## Related Issue 🍫

- close : #94 
## Summary 🍪

- 선물방 참여자 상세 조회 API에서 owner, room, room member정보를 한 번에 보냈는데 삭제 시 전체 삭제되는 문제로 owner& room과 room member를 보내는 로직을 분리합니다.
- room & owner 정보 => /api/room/{roomId}/room-detail
- room member 리스트 정보 => /api/room/{roomId}/members

## Before i request PR review 🍰
