### PR TITLE
[fix] 진행중, 종료 선물방 분류 기준 변경

### DIFF
--- a/src/main/java/org/sopt/sweet/domain/gift/dto/response/TournamentInfoDto.java
+++ b/src/main/java/org/sopt/sweet/domain/gift/dto/response/TournamentInfoDto.java
@@ -7,22 +7,18 @@ import java.time.LocalDateTime;
 
 @Builder
 public record TournamentInfoDto(
-        LocalDateTime tournamentStartDate,
-        TournamentDuration tournamentDuration,
-
-        int TotalParticipantsCount,
-        int ParticipantsCount
+        LocalDateTime remainingTime,
+        int totalParticipantsCount,
+        int participantsCount
 
 ) {
-    public static TournamentInfoDto of(LocalDateTime tournamentStartDate,
-                                       TournamentDuration tournamentDuration,
+    public static TournamentInfoDto of(LocalDateTime remainingTime,
                                        int TotalParticipantsCount,
                                        int ParticipantsCount) {
         return TournamentInfoDto.builder()
-                .tournamentStartDate(tournamentStartDate)
-                .tournamentDuration(tournamentDuration)
-                .TotalParticipantsCount(TotalParticipantsCount)
-                .ParticipantsCount(ParticipantsCount)
+                .remainingTime(remainingTime)
+                .totalParticipantsCount(TotalParticipantsCount)
+                .participantsCount(ParticipantsCount)
                 .build();
     }
 

--- a/src/main/java/org/sopt/sweet/domain/gift/service/GiftService.java
+++ b/src/main/java/org/sopt/sweet/domain/gift/service/GiftService.java
@@ -179,6 +179,7 @@ public class GiftService {
 
         LocalDateTime tournamentStartDate = room.getTournamentStartDate();
         TournamentDuration tournamentDuration = room.getTournamentDuration();
+
         int totalParticipantsCount = room.getGifterNumber();
 
         updateTournamentParticipation(memberId, roomId);
@@ -187,6 +188,8 @@ public class GiftService {
 
         return new TournamentInfoDto(tournamentStartDate, tournamentDuration, totalParticipantsCount, participatingMembersCount);
     }
+
+
 
     public void updateTournamentParticipation(Long memberId, Long roomId) {
         RoomMember roomMember = roomMemberRepository.findByRoomIdAndMemberId(roomId, memberId);

--- a/src/main/java/org/sopt/sweet/domain/gift/service/GiftService.java
+++ b/src/main/java/org/sopt/sweet/domain/gift/service/GiftService.java
@@ -2,7 +2,6 @@ package org.sopt.sweet.domain.gift.service;
 
 import lombok.RequiredArgsConstructor;
 import org.sopt.sweet.domain.gift.dto.request.CreateGiftRequestDto;
-import org.sopt.sweet.domain.gift.dto.request.MyGiftsRequestDto;
 import org.sopt.sweet.domain.gift.dto.request.TournamentScoreRequestDto;
 import org.sopt.sweet.domain.gift.dto.response.*;
 import org.sopt.sweet.domain.gift.entity.Gift;
@@ -20,6 +19,7 @@ import org.sopt.sweet.global.error.exception.ForbiddenException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -27,7 +27,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import static org.codehaus.groovy.runtime.DefaultGroovyMethods.collect;
 import static org.sopt.sweet.global.error.ErrorCode.*;
 
 @RequiredArgsConstructor
@@ -186,10 +185,25 @@ public class GiftService {
 
         int participatingMembersCount = roomMemberRepository.countByRoomIdAndTournamentParticipationIsTrue(roomId);
 
-        return new TournamentInfoDto(tournamentStartDate, tournamentDuration, totalParticipantsCount, participatingMembersCount);
+        LocalDateTime tournamentEndTime = getTournamentEndDate(tournamentStartDate, tournamentDuration);
+        LocalDateTime remainingTime =getTournamentRemainingTime(tournamentEndTime);
+
+        return new TournamentInfoDto(remainingTime, totalParticipantsCount, participatingMembersCount);
     }
 
 
+    private LocalDateTime getTournamentEndDate(LocalDateTime tournamentStartDate, TournamentDuration tournamentDuration) {
+        LocalDateTime tournamentEndTime = tournamentStartDate.plusHours(tournamentDuration.getHours());
+        return tournamentEndTime;
+    }
+
+
+    private LocalDateTime getTournamentRemainingTime(LocalDateTime tournamentEndTime) {
+        return tournamentEndTime
+                .minusHours(LocalDateTime.now().getHour())
+                .minusMinutes(LocalDateTime.now().getMinute())
+                .minusSeconds(LocalDateTime.now().getSecond());
+    }
 
     public void updateTournamentParticipation(Long memberId, Long roomId) {
         RoomMember roomMember = roomMemberRepository.findByRoomIdAndMemberId(roomId, memberId);


### PR DESCRIPTION
## Related Issue 🍫

- close : #105 

## Summary 🍪

- 진행중, 종료 선물방 분류 기준 & 정렬
선물 전달일 -> 토너먼트 종료일 기준으로 변경했습니다.

- 토너먼트 종료시 정보 조회 API response 변경되었습니다.(토너먼트 시작일, 지속시간 -> 토너먼트 남은 시간)