### PR TITLE
[refactor] 토너먼트 중복 참여 예외처리 & 로그인 로컬 환경 분리

### DIFF
--- a/src/main/java/org/sopt/sweet/domain/gift/controller/GiftController.java
+++ b/src/main/java/org/sopt/sweet/domain/gift/controller/GiftController.java
@@ -43,7 +43,7 @@ public class GiftController implements GiftApi {
 
     @GetMapping("/tournament/{roomId}")
     public ResponseEntity<SuccessResponse<?>> getTournamentGiftList(@UserId Long userId, @PathVariable Long roomId) {
-        List<TournamentListsResponseDto> tournamentGiftList = giftService.getTournamentGiftList(roomId);
+        List<TournamentListsResponseDto> tournamentGiftList = giftService.getTournamentGiftList(userId, roomId);
         return SuccessResponse.ok(tournamentGiftList);
     }
 

--- a/src/main/java/org/sopt/sweet/domain/gift/service/GiftService.java
+++ b/src/main/java/org/sopt/sweet/domain/gift/service/GiftService.java
@@ -136,8 +136,14 @@ public class GiftService {
     }
 
     @Transactional(readOnly = true)
-    public List<TournamentListsResponseDto> getTournamentGiftList(Long roomId) {
+    public List<TournamentListsResponseDto> getTournamentGiftList(Long memberId, Long roomId) {
         Room room = findRoomByIdOrThrow(roomId);
+        RoomMember roomMember = roomMemberRepository.findByRoomIdAndMemberId(roomId, memberId);
+
+        if(roomMember.isTournamentParticipation()){
+            throw new BusinessException(ALREADY_PARTICIPATED_TOURNAMENT);
+        }
+
         List<Gift> gifts = giftRepository.findByRoom(room);
         return mapGiftsToTournamentLists(gifts);
     }

--- a/src/main/java/org/sopt/sweet/domain/member/controller/OAuthApi.java
+++ b/src/main/java/org/sopt/sweet/domain/member/controller/OAuthApi.java
@@ -14,6 +14,7 @@ import org.sopt.sweet.global.config.auth.UserId;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "소셜로그인", description = "소셜로그인 관련 API")
@@ -38,7 +39,13 @@ public interface OAuthApi {
                     required = true,
                     example = "gGMvN1u_dgHdTizP8uUf7HZHNls_3G4X8qbKTwihE0x5W6f3E6acGDDsc80KPXLrAAABjO-2eHHUNEQ5evY1pg"
             )
-            @RequestParam("code") String code
+            @RequestParam("code") String code,
+            @Parameter(
+                    description = "환경변수",
+                    required = true,
+                    example = "development"
+            )
+            @RequestHeader("X-Environment") String environment
     );
 
     @ApiResponses(

--- a/src/main/java/org/sopt/sweet/domain/member/controller/OAuthController.java
+++ b/src/main/java/org/sopt/sweet/domain/member/controller/OAuthController.java
@@ -22,8 +22,8 @@ public class OAuthController implements OAuthApi {
     private final OAuthService oAuthService;
 
     @GetMapping("/kakao/login")
-    public ResponseEntity<SuccessResponse<?>> kakaoLogin(@RequestParam("code") String code) {
-        KakaoUserInfoResponseDto userInfo = oAuthService.kakaoCallback(code);
+    public ResponseEntity<SuccessResponse<?>> kakaoLogin(@RequestParam("code") String code, @RequestHeader("X-Environment") String environment) {
+        KakaoUserInfoResponseDto userInfo = oAuthService.kakaoCallback(code, environment);
         MemberTokenResponseDto memberToken = oAuthService.saveToken(userInfo.memberId());
 
         Map<String, Object> loginResponse = new HashMap<>();

--- a/src/main/java/org/sopt/sweet/domain/member/service/OAuthService.java
+++ b/src/main/java/org/sopt/sweet/domain/member/service/OAuthService.java
@@ -59,7 +59,7 @@ public class OAuthService {
     private final RedisTemplate<String, String> redisTemplate;
 
     // 카카오 로그인 시 회원 정보 조회
-    public KakaoUserInfoResponseDto kakaoCallback(String code) {
+    public KakaoUserInfoResponseDto kakaoCallback(String code, String environment) {
         RestTemplate restTemplate = new RestTemplate();
         HttpHeaders headers = new HttpHeaders();
         headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
@@ -68,6 +68,11 @@ public class OAuthService {
         params.add("grant_type", "authorization_code");
         params.add("client_id", clientId);
         params.add("redirect_uri", redirectUri);
+        if ("development".equals(environment)) {
+            params.add("redirect_uri", redirectUri);
+        } else {
+            params.add("redirect_uri", "http://localhost:5137/api/oauth/kakao/login");
+        }
         params.add("code", code);
 
         HttpEntity<MultiValueMap<String, String>> kakaoTokenRequest =

--- a/src/main/java/org/sopt/sweet/global/error/ErrorCode.java
+++ b/src/main/java/org/sopt/sweet/global/error/ErrorCode.java
@@ -18,7 +18,7 @@ public enum ErrorCode {
     MEMBER_GIFT_COUNT_EXCEEDED(HttpStatus.BAD_REQUEST, "최대 선물 등록 개수를 초과하였습니다."),
     TOURNAMENT_START_DATE_PASSED(HttpStatus.BAD_REQUEST, "토너먼트 시작 날짜가 지났습니다"),
     ROOM_OWNER_CANNOT_DELETE_SELF(HttpStatus.BAD_REQUEST, "방 개설자는 스스로를 삭제할 수 없습니다."),
-
+    ALREADY_PARTICIPATED_TOURNAMENT(HttpStatus.BAD_REQUEST, "이미 참가한 토너먼트입니다."),
     /**
      * 401 Unauthorized
      */
@@ -30,7 +30,6 @@ public enum ErrorCode {
     INVALID_REFRESH_TOKEN_VALUE(HttpStatus.UNAUTHORIZED, "리프레시 토큰의 값이 올바르지 않습니다."),
     EXPIRED_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "리프레시 토큰이 만료되었습니다. 다시 로그인해 주세요."),
     NOT_MATCH_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "일치하지 않는 리프레시 토큰입니다."),
-
     /**
      * 403 Forbidden
      */


### PR DESCRIPTION
## Related Issue 🍫

- close : #113 

## Summary 🍪

-  토너먼트 중복 참여 예외처리 추가
-  카카오 로그인 로컬환경일 때도 가능하게 수정

## Before i request PR review 🍰

- Header로 로컬인지 배포판인지에 따라 달리 받아서 리다이렉트 uri 구분했습니다. (근데 이게 맞을까...?)
