### PR TITLE
[feat] response 추가 및 코드 수정

### DIFF
--- a/src/main/java/org/sopt/sweet/domain/gift/controller/GiftController.java
+++ b/src/main/java/org/sopt/sweet/domain/gift/controller/GiftController.java
@@ -55,7 +55,7 @@ public class GiftController implements GiftApi {
 
     @PostMapping("/tournament-score")
     public ResponseEntity<SuccessResponse<?>> evaluateTournamentScore(@UserId Long userId, @RequestBody TournamentScoreRequestDto tournamentScoreRequestDto) {
-        giftService.evaluateTournamentScore(tournamentScoreRequestDto);
+        giftService.evaluateTournamentScore(userId,tournamentScoreRequestDto);
         return SuccessResponse.created(null);
     }
 

--- a/src/main/java/org/sopt/sweet/domain/gift/controller/GiftController.java
+++ b/src/main/java/org/sopt/sweet/domain/gift/controller/GiftController.java
@@ -31,8 +31,14 @@ public class GiftController implements GiftApi {
 
     @GetMapping("/my/{roomId}")
     public ResponseEntity<SuccessResponse<?>> getMyGift(@UserId Long userId, @PathVariable Long roomId) {
+        String gifteename = giftService.getGifteeName(roomId);
         final MyGiftsResponseDto myGiftsResponseDto = giftService.getMyGift(userId, roomId);
-        return SuccessResponse.ok(myGiftsResponseDto);
+
+        Map<String, Object> result = new HashMap<>();
+        result.put("gifteeName", gifteename);
+        result.put("myGiftsResponseDto", myGiftsResponseDto);
+
+        return SuccessResponse.ok(result);
     }
 
 
@@ -40,6 +46,18 @@ public class GiftController implements GiftApi {
     public ResponseEntity<SuccessResponse<?>> deleteMyGift(@UserId Long userId, @PathVariable Long giftId) {
         giftService.deleteMyGift(userId, giftId);
         return SuccessResponse.ok(null);
+    }
+
+    @GetMapping("/friend/{roomId}")
+    public ResponseEntity<SuccessResponse<?>> getFriendGift(@UserId Long userId, @PathVariable Long roomId) {
+        RoomInfoResponseDto roomInfoResponseDto = giftService.getRoomInfo(roomId);
+        final List<FriendGiftDto> friendGiftList = giftService.getFriendGift(userId, roomId);
+
+        Map<String, Object> result = new HashMap<>();
+        result.put("roomInfoResponseDto", roomInfoResponseDto);
+        result.put("friendGiftDto", friendGiftList);
+        return SuccessResponse.ok(result);
+
     }
 
     @GetMapping("/tournament/{roomId}")
@@ -71,17 +89,7 @@ public class GiftController implements GiftApi {
         return SuccessResponse.ok(ranking);
     }
 
-    @GetMapping("/friend/{roomId}")
-    public ResponseEntity<SuccessResponse<?>> getFriendGift(@UserId Long userId, @PathVariable Long roomId) {
-        RoomInfoResponseDto roomInfoResponseDto = giftService.getRoomInfo(roomId);
-        final List<FriendGiftDto> friendGiftList = giftService.getFriendGift(userId, roomId);
 
-        Map<String, Object> result = new HashMap<>();
-        result.put("roomInfoResponseDto", roomInfoResponseDto);
-        result.put("friendGiftDto", friendGiftList);
-        return SuccessResponse.ok(result);
-
-    }
 
 
 }

--- a/src/main/java/org/sopt/sweet/domain/gift/dto/response/TournamentInfoDto.java
+++ b/src/main/java/org/sopt/sweet/domain/gift/dto/response/TournamentInfoDto.java
@@ -7,18 +7,28 @@ import java.time.LocalDateTime;
 
 @Builder
 public record TournamentInfoDto(
+
+        String firstplaceGiftName,
+        String firstplaceGiftImageUrl,
+        int firstplaceGiftCost,
         LocalDateTime remainingTime,
         int totalParticipantsCount,
         int participantsCount
 
 ) {
-    public static TournamentInfoDto of(LocalDateTime remainingTime,
-                                       int TotalParticipantsCount,
-                                       int ParticipantsCount) {
+    public static TournamentInfoDto of( String firstplaceGiftName,
+                                        String firstplaceGiftImageUrl,
+                                        int firstplaceGiftCost,
+                                        LocalDateTime remainingTime,
+                                        int totalParticipantsCount,
+                                        int participantsCount) {
         return TournamentInfoDto.builder()
+                .firstplaceGiftName(firstplaceGiftName)
+                .firstplaceGiftImageUrl(firstplaceGiftImageUrl)
+                .firstplaceGiftCost(firstplaceGiftCost)
                 .remainingTime(remainingTime)
-                .totalParticipantsCount(TotalParticipantsCount)
-                .participantsCount(ParticipantsCount)
+                .totalParticipantsCount(totalParticipantsCount)
+                .participantsCount(participantsCount)
                 .build();
     }
 

--- a/src/main/java/org/sopt/sweet/domain/gift/entity/Gift.java
+++ b/src/main/java/org/sopt/sweet/domain/gift/entity/Gift.java
@@ -7,7 +7,10 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.sopt.sweet.domain.member.entity.Member;
 import org.sopt.sweet.domain.room.entity.Room;
+import org.sopt.sweet.domain.room.entity.RoomMember;
 import org.sopt.sweet.global.common.BaseTimeEntity;
+
+import java.util.List;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -41,6 +44,10 @@ public class Gift extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
+
+    @OneToMany(mappedBy = "id")
+    private List<RoomMember> roomMembers;
+
 
     @Builder
     public Gift(String url, String name, int cost, String imageUrl, Room room, Member member) {

--- a/src/main/java/org/sopt/sweet/domain/gift/service/GiftService.java
+++ b/src/main/java/org/sopt/sweet/domain/gift/service/GiftService.java
@@ -163,13 +163,15 @@ public class GiftService {
 
     public void evaluateTournamentScore(Long memberId, TournamentScoreRequestDto tournamentScoreRequestDto) {
         Gift gift = findByIdOrThrow(tournamentScoreRequestDto.finalGiftId());
-        System.out.println(gift);
         Room room = gift.getRoom();
-        System.out.println(room);
+
+        //1등 상품 저장하기
         RoomMember roomMember = roomMemberRepository.findByRoomIdAndMemberId(room.getId(), memberId);
-        System.out.println(roomMember);
         roomMember.setFirstplaceGiftId(tournamentScoreRequestDto.finalGiftId());
         roomMemberRepository.save(roomMember);
+
+        //토너먼트 참여 여부 업데이트
+        updateTournamentParticipation(memberId, room.getId());
 
         Long firstGiftId = tournamentScoreRequestDto.firstGiftId();
         Long secondGiftId = tournamentScoreRequestDto.secondGiftId();
@@ -204,8 +206,6 @@ public class GiftService {
         TournamentDuration tournamentDuration = room.getTournamentDuration();
 
         int totalParticipantsCount = room.getGifterNumber();
-
-        updateTournamentParticipation(memberId, roomId);
 
         int participatingMembersCount = roomMemberRepository.countByRoomIdAndTournamentParticipationIsTrue(roomId);
 

--- a/src/main/java/org/sopt/sweet/domain/gift/service/GiftService.java
+++ b/src/main/java/org/sopt/sweet/domain/gift/service/GiftService.java
@@ -161,7 +161,16 @@ public class GiftService {
                 .collect(Collectors.toList());
     }
 
-    public void evaluateTournamentScore(TournamentScoreRequestDto tournamentScoreRequestDto) {
+    public void evaluateTournamentScore(Long memberId, TournamentScoreRequestDto tournamentScoreRequestDto) {
+        Gift gift = findByIdOrThrow(tournamentScoreRequestDto.finalGiftId());
+        System.out.println(gift);
+        Room room = gift.getRoom();
+        System.out.println(room);
+        RoomMember roomMember = roomMemberRepository.findByRoomIdAndMemberId(room.getId(), memberId);
+        System.out.println(roomMember);
+        roomMember.setFirstplaceGiftId(tournamentScoreRequestDto.finalGiftId());
+        roomMemberRepository.save(roomMember);
+
         Long firstGiftId = tournamentScoreRequestDto.firstGiftId();
         Long secondGiftId = tournamentScoreRequestDto.secondGiftId();
         Long finalGiftId = tournamentScoreRequestDto.finalGiftId();

--- a/src/main/java/org/sopt/sweet/domain/gift/service/GiftService.java
+++ b/src/main/java/org/sopt/sweet/domain/gift/service/GiftService.java
@@ -201,6 +201,9 @@ public class GiftService {
 
     public TournamentInfoDto getTournamentInfo(Long memberId, Long roomId) {
         Room room = findRoomByIdOrThrow(roomId);
+        RoomMember roomMember = roomMemberRepository.findByRoomIdAndMemberId(roomId, memberId);
+        Gift firstPlaceGift = giftRepository.findById(roomMember.getFirstplaceGiftId())
+                .orElseThrow(() -> new EntityNotFoundException(GIFT_NOT_FOUND));
 
         LocalDateTime tournamentStartDate = room.getTournamentStartDate();
         TournamentDuration tournamentDuration = room.getTournamentDuration();
@@ -212,9 +215,10 @@ public class GiftService {
         LocalDateTime tournamentEndTime = getTournamentEndDate(tournamentStartDate, tournamentDuration);
         LocalDateTime remainingTime =getTournamentRemainingTime(tournamentEndTime);
 
-        return new TournamentInfoDto(remainingTime, totalParticipantsCount, participatingMembersCount);
+        return new TournamentInfoDto(
+                firstPlaceGift.getName(), firstPlaceGift.getImageUrl(), firstPlaceGift.getCost(),
+                remainingTime, totalParticipantsCount, participatingMembersCount);
     }
-
 
     private LocalDateTime getTournamentEndDate(LocalDateTime tournamentStartDate, TournamentDuration tournamentDuration) {
         LocalDateTime tournamentEndTime = tournamentStartDate.plusHours(tournamentDuration.getHours());

--- a/src/main/java/org/sopt/sweet/domain/gift/service/GiftService.java
+++ b/src/main/java/org/sopt/sweet/domain/gift/service/GiftService.java
@@ -294,4 +294,12 @@ public class GiftService {
         LocalDateTime tournamentStartDate = room.getTournamentStartDate();
         return new RoomInfoResponseDto(gifteeName,tournamentStartDate);
     }
+
+
+    public String getGifteeName(Long roomId) {
+        Room room = findRoomByIdOrThrow(roomId);
+        String gifteeName = room.getGifteeName();
+        return gifteeName;
+    }
+
 }

--- a/src/main/java/org/sopt/sweet/domain/room/entity/RoomMember.java
+++ b/src/main/java/org/sopt/sweet/domain/room/entity/RoomMember.java
@@ -29,6 +29,9 @@ public class RoomMember extends BaseTimeEntity {
     @Column(columnDefinition = "TINYINT(1) default 0")
     private boolean tournamentParticipation;
 
+    @Column(name = "firstplace_gift_id")
+    private Long firstplaceGiftId;
+
     @Builder
     public RoomMember(Room room, Member member) {
         this.room = room;
@@ -39,4 +42,7 @@ public class RoomMember extends BaseTimeEntity {
         this.tournamentParticipation = tournamentParticipation;
     }
 
+    public void setFirstplaceGiftId(Long firstplaceGiftId) {
+         this.firstplaceGiftId = firstplaceGiftId;
+     }
 }


### PR DESCRIPTION
## Related Issue 🍫

- close : #119

## Summary 🍪

- api/gift/my{roomId} 호출 시 gifteename response에 추가하였습니다.
- 토너먼트 참가여부 업데이트 로직은 api/gift/tournament-score으로 이동하였습니다.
- roomMember 테이블에 1등 상품으로 선택한 giftId를 저장할 수 있는 필드를 추가하였고 api/gift/tournament-info호출 시 response에 1등 상품 정보를 추가하였습니다.

## Before i request PR review 🍰

