### PR TITLE
[feat] #122 tournament 종료 API 구현

### DIFF
--- a/src/main/java/org/sopt/sweet/domain/gift/controller/GiftController.java
+++ b/src/main/java/org/sopt/sweet/domain/gift/controller/GiftController.java
@@ -89,7 +89,7 @@ public class GiftController implements GiftApi {
         return SuccessResponse.ok(ranking);
     }
 
-    @PostMapping("/tournament/end/{roomId}")
+    @PostMapping("/tournament-end/{roomId}")
     public ResponseEntity<SuccessResponse<?>> endTournament(@UserId Long userId, @PathVariable Long roomId) {
         giftService.endTournament(roomId);
         return SuccessResponse.created(null);

--- a/src/main/java/org/sopt/sweet/domain/gift/controller/GiftController.java
+++ b/src/main/java/org/sopt/sweet/domain/gift/controller/GiftController.java
@@ -89,6 +89,12 @@ public class GiftController implements GiftApi {
         return SuccessResponse.ok(ranking);
     }
 
+    @PostMapping("/tournament/end/{roomId}")
+    public ResponseEntity<SuccessResponse<?>> endTournament(@UserId Long userId, @PathVariable Long roomId) {
+        giftService.endTournament(roomId);
+        return SuccessResponse.created(null);
+    }
+
 
 
 

--- a/src/main/java/org/sopt/sweet/domain/gift/service/GiftService.java
+++ b/src/main/java/org/sopt/sweet/domain/gift/service/GiftService.java
@@ -312,4 +312,12 @@ public class GiftService {
         return gifteeName;
     }
 
+    public void endTournament(Long roomId) {
+        Room room = findRoomByIdOrThrow(roomId);
+        TournamentDuration tournamentDuration = room.getTournamentDuration();
+        LocalDateTime newStartDate = LocalDateTime.now().minusHours(tournamentDuration.getHours());
+        room.setTournamentStartDate(newStartDate);
+
+    }
+
 }

--- a/src/main/java/org/sopt/sweet/domain/room/entity/Room.java
+++ b/src/main/java/org/sopt/sweet/domain/room/entity/Room.java
@@ -69,4 +69,7 @@ public class Room extends BaseTimeEntity {
     public void setGifteeName(String gifteeName) {
         this.gifteeName = gifteeName;
     }
+
+    public  void setTournamentStartDate(LocalDateTime tournamentStartDate) { this.tournamentStartDate = tournamentStartDate;
+    }
 }


### PR DESCRIPTION
## Related Issue 🍫

- close : #122 

## Summary 🍪

- 토너먼트 종료 API 구현

## Before i request PR review 🍰
토너먼트 종료 시간에 대한 필드 추가도 고민해봤는데 다른 api에서 토너먼트 종료시간 계산을 TournamentStartDate랑 duration으로해서 꼬일 거 같아서 TournamentStartDate(토너먼트 시작 시간)을 조정하는 방향으로 구현했습니다. (TournamentStartDate =  현재시간 - duration)
